### PR TITLE
Parameter defintion reference

### DIFF
--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -252,7 +252,7 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
         APPEND '"in":"query",' TO lt_string.
       ELSE.
         APPEND '"in":"body",' TO lt_string.
-        lv_string = |"schema": \{"$ref": "#/definitions/' { is_meta-meta-handler } '_Request"\}|.
+        lv_string = |"schema": \{"$ref": "#/definitions/{ is_meta-meta-handler }_Request"\}|.
         APPEND lv_string TO lt_string.
         APPEND '},' TO lt_string.
         request( is_meta     = is_meta


### PR DESCRIPTION
Non GET methods are creating an incorrect reference to parameters
![image](https://user-images.githubusercontent.com/56556686/84761084-36bf1080-afc9-11ea-897a-d3dbd59a1906.png)
