### PR TITLE
Remove DATA from reply option, fixed tests

### DIFF
--- a/src/zcl_dummy_swagger_handler.clas.abap
+++ b/src/zcl_dummy_swagger_handler.clas.abap
@@ -1,0 +1,51 @@
+class zcl_dummy_swagger_handler definition create public
+for testing
+public.
+
+  public section.
+    interfaces zif_swag_handler.
+    types:
+      begin of ty_structure,
+        foo type string,
+        bar type string,
+        foo_bar type string,
+      end of ty_structure.
+
+    methods the_real_stuff
+      importing
+        !iv_foo        type string optional
+        !iv_bar        type string optional
+      returning
+        value(rs_data) type ty_structure.
+    methods
+      set_meta
+        importing
+          it_meta type zcl_swag=>ty_meta_tt.
+  protected section.
+  private section.
+    data mt_meta type zcl_swag=>ty_meta_tt.
+
+endclass.
+
+class zcl_dummy_swagger_handler implementation.
+
+  method the_real_stuff.
+
+    concatenate iv_foo iv_bar into rs_data-foo.
+    rs_data-bar = iv_bar.
+    rs_data-foo_bar = 'FOO_BAR'.
+
+  endmethod.
+
+
+  method zif_swag_handler~meta.
+
+    rt_meta = mt_meta.
+
+  endmethod.
+
+  method set_meta.
+    mt_meta = it_meta.
+  endmethod.
+
+endclass.

--- a/src/zcl_dummy_swagger_handler.clas.xml
+++ b/src/zcl_dummy_swagger_handler.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_DUMMY_SWAGGER_HANDLER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>A dummy for tests</DESCRIPT>
+    <CATEGORY>05</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -664,12 +664,14 @@ CLASS zcl_swag IMPLEMENTATION.
 
     IF is_meta-meta-response_settings-remove_data_object = abap_true.
 
-
       DATA lv_length TYPE i.
       DATA lv_minus_data TYPE i.
       lv_length = strlen( cv_data_as_string ).
       lv_minus_data = lv_length - 9.
 
+      IF lv_minus_data <= 0.
+        RETURN.
+      ENDIF.
       "start has |{"DATA":| (8) end has |}| (1)
       cv_data_as_string = cv_data_as_string+8(lv_minus_data).
     ENDIF.


### PR DESCRIPTION
Hello Lars, 
Good afternoon. 
This is to fix issue [#24](https://github.com/larshp/ABAP-Swagger/issues/24), my idea was to be the least disruptive and keep syntax to old elements. 
This also fix [#45](https://github.com/larshp/ABAP-Swagger/issues/45) (broken tests) and adds a new one for this feature.  

Basically I added a new structure to the meta.
```
    TYPES:
      BEGIN OF sty_response,
        remove_data_object TYPE abap_bool,
      END OF sty_response.
    TYPES:
      BEGIN OF ty_meta,
        ...
        response_settings TYPE sty_response,
      END OF ty_meta .
```
And calling a handle_response on json_reply that will eventually:

      DATA lv_length TYPE i.
      DATA lv_minus_data TYPE i.
      lv_length = strlen( cv_data_as_string ).
      lv_minus_data = lv_length - 9.

      IF lv_minus_data <= 0.
        RETURN.
      ENDIF.
      "start has |{"DATA":| (8) end has |}| (1)
      cv_data_as_string = cv_data_as_string+8(lv_minus_data).

Regards,
Felipe 