### PR TITLE
Option to remove DATA from reply option, fixed tests

### DIFF
--- a/src/zcl_dummy_swagger_handler.clas.abap
+++ b/src/zcl_dummy_swagger_handler.clas.abap
@@ -1,51 +1,51 @@
-class zcl_dummy_swagger_handler definition create public
-for testing
-public.
+CLASS zcl_dummy_swagger_handler DEFINITION CREATE PUBLIC
+  FOR TESTING
+  PUBLIC.
 
-  public section.
-    interfaces zif_swag_handler.
-    types:
-      begin of ty_structure,
-        foo type string,
-        bar type string,
-        foo_bar type string,
-      end of ty_structure.
+  PUBLIC SECTION.
+    INTERFACES zif_swag_handler.
+    TYPES:
+      BEGIN OF ty_structure,
+        foo     TYPE string,
+        bar     TYPE string,
+        foo_bar TYPE string,
+      END OF ty_structure.
 
-    methods the_real_stuff
-      importing
-        !iv_foo        type string optional
-        !iv_bar        type string optional
-      returning
-        value(rs_data) type ty_structure.
-    methods
+    METHODS the_real_stuff
+      IMPORTING
+        !iv_foo        TYPE string OPTIONAL
+        !iv_bar        TYPE string OPTIONAL
+      RETURNING
+        VALUE(rs_data) TYPE ty_structure.
+    METHODS
       set_meta
-        importing
-          it_meta type zcl_swag=>ty_meta_tt.
-  protected section.
-  private section.
-    data mt_meta type zcl_swag=>ty_meta_tt.
+        IMPORTING
+          it_meta TYPE zcl_swag=>ty_meta_tt.
+  PROTECTED SECTION.
+  PRIVATE SECTION.
+    DATA mt_meta TYPE zcl_swag=>ty_meta_tt.
 
-endclass.
+ENDCLASS.
 
-class zcl_dummy_swagger_handler implementation.
+CLASS zcl_dummy_swagger_handler IMPLEMENTATION.
 
-  method the_real_stuff.
+  METHOD the_real_stuff.
 
-    concatenate iv_foo iv_bar into rs_data-foo.
+    CONCATENATE iv_foo iv_bar INTO rs_data-foo.
     rs_data-bar = iv_bar.
     rs_data-foo_bar = 'FOO_BAR'.
 
-  endmethod.
+  ENDMETHOD.
 
 
-  method zif_swag_handler~meta.
+  METHOD zif_swag_handler~meta.
 
     rt_meta = mt_meta.
 
-  endmethod.
+  ENDMETHOD.
 
-  method set_meta.
+  METHOD set_meta.
     mt_meta = it_meta.
-  endmethod.
+  ENDMETHOD.
 
-endclass.
+ENDCLASS.

--- a/src/zcl_dummy_swagger_handler.clas.abap
+++ b/src/zcl_dummy_swagger_handler.clas.abap
@@ -1,0 +1,51 @@
+class zcl_dummy_swagger_handler definition create public
+for testing
+public.
+
+  public section.
+    interfaces zif_swag_handler.
+    types:
+      begin of ty_structure,
+        foo type string,
+        bar type string,
+        foo_bar type string,
+      end of ty_structure.
+
+    methods the_real_stuff
+      importing
+        !iv_foo        type string optional
+        !iv_bar        type string optional
+      returning
+        value(rs_data) type ty_structure.
+    methods
+      set_meta
+        importing
+          it_meta type zcl_swag=>ty_meta_tt.
+  protected section.
+  private section.
+    data mt_meta type zcl_swag=>ty_meta_tt.
+
+endclass.
+
+class zcl_dummy_swagger_handler implementation.
+
+  method the_real_stuff.
+
+    concatenate iv_foo iv_bar into rs_data-foo.
+    rs_data-bar = iv_bar.
+    rs_data-foo_bar = 'FOO_BAR'.
+
+  endmethod.
+
+
+  method zif_swag_handler~meta.
+
+    rt_meta = mt_meta.
+
+  endmethod.
+
+  method set_meta.
+    mt_meta = it_meta.
+  endmethod.
+
+endclass.

--- a/src/zcl_dummy_swagger_handler.clas.xml
+++ b/src/zcl_dummy_swagger_handler.clas.xml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<abapGit version="v1.0.0" serializer="LCL_OBJECT_CLAS" serializer_version="v1.0.0">
+ <asx:abap xmlns:asx="http://www.sap.com/abapxml" version="1.0">
+  <asx:values>
+   <VSEOCLASS>
+    <CLSNAME>ZCL_DUMMY_SWAGGER_HANDLER</CLSNAME>
+    <LANGU>E</LANGU>
+    <DESCRIPT>A dummy for tests</DESCRIPT>
+    <CATEGORY>05</CATEGORY>
+    <STATE>1</STATE>
+    <CLSCCINCL>X</CLSCCINCL>
+    <FIXPT>X</FIXPT>
+    <UNICODE>X</UNICODE>
+   </VSEOCLASS>
+  </asx:values>
+ </asx:abap>
+</abapGit>

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -664,12 +664,14 @@ CLASS zcl_swag IMPLEMENTATION.
 
     IF is_meta-meta-response_settings-remove_data_object = abap_true.
 
-
       DATA lv_length TYPE i.
       DATA lv_minus_data TYPE i.
       lv_length = strlen( cv_data_as_string ).
       lv_minus_data = lv_length - 9.
 
+      IF lv_minus_data <= 0.
+        RETURN.
+      ENDIF.
       "start has |{"DATA":| (8) end has |}| (1)
       cv_data_as_string = cv_data_as_string+8(lv_minus_data).
     ENDIF.

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -20,9 +20,9 @@ CLASS zcl_swag DEFINITION
         group_names TYPE STANDARD TABLE OF seosconame WITH DEFAULT KEY,
       END OF ty_url .
     TYPES:
-      BEGIN OF sty_response,
+      BEGIN OF ty_response,
         remove_data_object TYPE abap_bool,
-      END OF sty_response.
+      END OF ty_response.
     TYPES:
       BEGIN OF ty_meta,
         summary           TYPE string,
@@ -30,7 +30,7 @@ CLASS zcl_swag DEFINITION
         method            TYPE string,
         handler           TYPE string,
         tags              TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
-        response_settings TYPE sty_response,
+        response_settings TYPE ty_response,
       END OF ty_meta .
     TYPES:
       BEGIN OF ty_meta_internal,
@@ -121,7 +121,7 @@ CLASS zcl_swag DEFINITION
   PRIVATE SECTION.
     METHODS handle_response
       IMPORTING
-        is_meta          TYPE zcl_swag=>ty_meta_internal
+        is_meta          TYPE ty_meta_internal
         iv_abap_response TYPE any
       CHANGING
         cv_data          TYPE xstring
@@ -132,7 +132,7 @@ CLASS zcl_swag DEFINITION
         cx_sy_conversion_codepage .
     METHODS handle_remove_data_object
       IMPORTING
-        is_meta           TYPE zcl_swag=>ty_meta_internal
+        is_meta           TYPE ty_meta_internal
       CHANGING
         cv_data_as_string TYPE string
       RAISING
@@ -638,9 +638,7 @@ CLASS zcl_swag IMPLEMENTATION.
       lv_data_as_string    TYPE string.
 
     lo_xstring_to_string = cl_abap_conv_in_ce=>create( input = cv_data ).
-    lo_xstring_to_string->read(
-      IMPORTING
-        data = lv_data_as_string ).
+    lo_xstring_to_string->read( IMPORTING data = lv_data_as_string ).
 
     handle_remove_data_object(
           EXPORTING
@@ -653,8 +651,7 @@ CLASS zcl_swag IMPLEMENTATION.
       EXPORTING
           data = lv_data_as_string
       IMPORTING
-          buffer = cv_data
-    ).
+          buffer = cv_data ).
 
 
   ENDMETHOD.
@@ -662,22 +659,19 @@ CLASS zcl_swag IMPLEMENTATION.
 
   METHOD handle_remove_data_object.
 
+    DATA lv_length TYPE i.
+    DATA lv_minus_data TYPE i.
+
     IF is_meta-meta-response_settings-remove_data_object = abap_true.
 
-      DATA lv_length TYPE i.
-      DATA lv_minus_data TYPE i.
       lv_length = strlen( cv_data_as_string ).
       lv_minus_data = lv_length - 9.
 
-      IF lv_minus_data <= 0.
-        RETURN.
-      ENDIF.
       "start has |{"DATA":| (8) end has |}| (1)
       cv_data_as_string = cv_data_as_string+8(lv_minus_data).
+
     ENDIF.
 
   ENDMETHOD.
-
-
 
 ENDCLASS.

--- a/src/zcl_swag.clas.testclasses.abap
+++ b/src/zcl_swag.clas.testclasses.abap
@@ -20,13 +20,12 @@ CLASS ltcl_swag DEFINITION FOR TESTING
           mo_dummy_handler TYPE REF TO zcl_dummy_swagger_handler.
 
     METHODS: setup,
-      given_a_foobar_meta
-        IMPORTING
-          iv_remove_data_object TYPE any OPTIONAL
-            PREFERRED PARAMETER iv_remove_data_object,
-      new_swag_instance,
       test FOR TESTING RAISING cx_static_check,
-      remove_data_object_setting FOR TESTING.
+      remove_data_object_setting FOR TESTING,
+      new_swag_instance,
+      given_a_foobar_meta
+      IMPORTING
+        iv_remove_data_object TYPE abap_bool OPTIONAL.
 
     CLASS-METHODS: to_string
       IMPORTING iv_xstr       TYPE xstring

--- a/src/zcl_swag.clas.testclasses.abap
+++ b/src/zcl_swag.clas.testclasses.abap
@@ -112,7 +112,7 @@ CLASS ltcl_swag IMPLEMENTATION.
   ENDMETHOD.                    "test
 
   METHOD if_http_entity~set_cdata.
-    mv_reply = to_string( CONV #( data ) ).
+    mv_reply = data.
   ENDMETHOD.                    "if_http_entity~set_data
 
   METHOD if_http_request~get_form_field.

--- a/src/zcl_swag.clas.testclasses.abap
+++ b/src/zcl_swag.clas.testclasses.abap
@@ -20,12 +20,10 @@ CLASS ltcl_swag DEFINITION FOR TESTING
           mo_dummy_handler TYPE REF TO zcl_dummy_swagger_handler.
 
     METHODS: setup,
-
       given_a_foobar_meta
         IMPORTING
           iv_remove_data_object TYPE any OPTIONAL
             PREFERRED PARAMETER iv_remove_data_object,
-
       new_swag_instance,
       test FOR TESTING RAISING cx_static_check,
       remove_data_object_setting FOR TESTING.
@@ -133,9 +131,7 @@ CLASS ltcl_swag IMPLEMENTATION.
   METHOD remove_data_object_setting.
 
     "Keep DATA
-    given_a_foobar_meta(
-        iv_remove_data_object = abap_false
-    ).
+    given_a_foobar_meta( iv_remove_data_object = abap_false ).
 
     mo_swag->register( mo_dummy_handler ).
     mo_swag->run( ).
@@ -149,9 +145,7 @@ CLASS ltcl_swag IMPLEMENTATION.
     new_swag_instance( ).
 
     "Remove DATA
-    given_a_foobar_meta(
-        iv_remove_data_object = abap_true
-    ).
+    given_a_foobar_meta( iv_remove_data_object = abap_true ).
 
     mo_swag->register( mo_dummy_handler ).
     mo_swag->run( ).
@@ -170,7 +164,7 @@ CLASS ltcl_swag IMPLEMENTATION.
 
 
     APPEND INITIAL LINE TO lt_foo_bar_meta ASSIGNING <ls_meta>.
-    <ls_meta>-summary   = 'this is the description'(001).
+    <ls_meta>-summary   = 'this is the description'.
     <ls_meta>-url-regex = '/swag/(\w*)/(\w*)'.
     APPEND 'IV_FOO' TO <ls_meta>-url-group_names.
     APPEND 'IV_BAR' TO <ls_meta>-url-group_names.
@@ -178,9 +172,7 @@ CLASS ltcl_swag IMPLEMENTATION.
     <ls_meta>-handler   = 'THE_REAL_STUFF'.
     <ls_meta>-response_settings-remove_data_object = iv_remove_data_object.
 
-    mo_dummy_handler->set_meta(
-        lt_foo_bar_meta
-    ).
+    mo_dummy_handler->set_meta( lt_foo_bar_meta ).
 
   ENDMETHOD.
 


### PR DESCRIPTION
Hello Lars,
Good afternoon.
This is to fix issue #24, my idea was to be the least disruptive and keep syntax to old elements.
This also fix #45 (broken tests) and adds a new one for this feature.

Basically I added a new structure to the meta.

    TYPES:
      BEGIN OF sty_response,
        remove_data_object TYPE abap_bool,
      END OF sty_response.
    TYPES:
      BEGIN OF ty_meta,
        ...
        response_settings TYPE sty_response,
      END OF ty_meta .
And calling a handle_response on json_reply that will eventually:

  DATA lv_length TYPE i.
  DATA lv_minus_data TYPE i.
  lv_length = strlen( cv_data_as_string ).
  lv_minus_data = lv_length - 9.

  IF lv_minus_data <= 0.
    RETURN.
  ENDIF.
  "start has |{"DATA":| (8) end has |}| (1)
  cv_data_as_string = cv_data_as_string+8(lv_minus_data).
Regards,
Felipe