### PR TITLE
Add possibility to use tag descriptions

### DIFF
--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -1,22 +1,22 @@
-class ZCL_SWAG definition
-  public
-  create public .
+CLASS zcl_swag DEFINITION
+  PUBLIC
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  types:
-    ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
-  types:
-    BEGIN OF ty_url,
+    TYPES:
+      ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
+    TYPES:
+      BEGIN OF ty_url,
         regex       TYPE string,
         group_names TYPE STANDARD TABLE OF seosconame WITH DEFAULT KEY,
       END OF ty_url .
-  types:
-    BEGIN OF ty_response,
+    TYPES:
+      BEGIN OF ty_response,
         remove_data_object TYPE abap_bool,
       END OF ty_response .
-  types:
-    BEGIN OF ty_meta,
+    TYPES:
+      BEGIN OF ty_meta,
         summary           TYPE string,
         url               TYPE ty_url,
         method            TYPE string,
@@ -24,62 +24,62 @@ public section.
         tags              TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
         response_settings TYPE ty_response,
       END OF ty_meta .
-  types:
-    BEGIN OF ty_meta_internal,
+    TYPES:
+      BEGIN OF ty_meta_internal,
         meta       TYPE ty_meta,
         obj        TYPE REF TO object,
         parameters TYPE ty_parameters_tt,
         classname  TYPE seoclsname,
       END OF ty_meta_internal .
-  types:
-    ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
-  types:
-    ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
-  types:
-    BEGIN OF ty_externaldoc,
+    TYPES:
+      ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
+    TYPES:
+      ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
+    TYPES:
+      BEGIN OF ty_externaldoc,
         description TYPE string,
         url         TYPE string,
       END OF ty_externaldoc .
-  types:
-    BEGIN OF ty_tagdescription,
+    TYPES:
+      BEGIN OF ty_tagdescription,
         tag         TYPE string,
         description TYPE string,
         externaldoc TYPE ty_externaldoc,
       END OF ty_tagdescription .
-  types:
-    ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
+    TYPES:
+      ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
 
-  constants:
-    BEGIN OF c_parm_kind,
+    CONSTANTS:
+      BEGIN OF c_parm_kind,
         importing TYPE seopardecl VALUE '0',
         exporting TYPE seopardecl VALUE '1',
         changing  TYPE seopardecl VALUE '2',
         returning TYPE seopardecl VALUE '3',
       END OF c_parm_kind .
-  constants:
-    BEGIN OF c_method,
+    CONSTANTS:
+      BEGIN OF c_method,
         get    TYPE string VALUE 'GET',
         post   TYPE string VALUE 'POST',
         put    TYPE string VALUE 'PUT',
         delete TYPE string VALUE 'DELETE',
       END OF c_method .
 
-  methods CONSTRUCTOR
-    importing
-      !II_SERVER type ref to IF_HTTP_SERVER
-      !IV_BASE type STRING
-      !IV_SWAGGER_JSON type STRING default '/swagger.json'
-      !IV_SWAGGER_HTML type STRING default '/swagger.html'
-      !IV_TITLE type STRING .
-  methods REGISTER
-    importing
-      !II_HANDLER type ref to ZIF_SWAG_HANDLER .
-  methods RUN
-    raising
-      CX_STATIC_CHECK .
-  methods SET_TAGDESCRIPTION
-    importing
-      !IS_DESCRIPTION type TY_TAGDESCRIPTION .
+    METHODS constructor
+      IMPORTING
+        !ii_server       TYPE REF TO if_http_server
+        !iv_base         TYPE string
+        !iv_swagger_json TYPE string DEFAULT '/swagger.json'
+        !iv_swagger_html TYPE string DEFAULT '/swagger.html'
+        !iv_title        TYPE string .
+    METHODS register
+      IMPORTING
+        !ii_handler TYPE REF TO zif_swag_handler .
+    METHODS run
+      RAISING
+        cx_static_check .
+    METHODS set_tagdescription
+      IMPORTING
+        !is_description TYPE ty_tagdescription .
   PROTECTED SECTION.
 
     DATA mv_base TYPE string .

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -659,11 +659,11 @@ CLASS ZCL_SWAG IMPLEMENTATION.
 
   METHOD set_tagdescription.
 
-    APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<tagdescription>).
-    <tagdescription>-tag = iv_tag.
-    <tagdescription>-description = iv_description.
-    <tagdescription>-externaldoc-description = iv_externaldoc-description.
-    <tagdescription>-externaldoc-url = iv_externaldoc-url.
+    APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<ls_tagdescription>).
+    <ls_tagdescription>-tag = iv_tag.
+    <ls_tagdescription>-description = iv_description.
+    <ls_tagdescription>-externaldoc-description = iv_externaldoc-description.
+    <ls_tagdescription>-externaldoc-url = iv_externaldoc-url.
 
   ENDMETHOD.
 

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -1,22 +1,22 @@
-class ZCL_SWAG definition
-  public
-  create public .
+CLASS zcl_swag DEFINITION
+  PUBLIC
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  types:
-    ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
-  types:
-    BEGIN OF ty_url,
+    TYPES:
+      ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
+    TYPES:
+      BEGIN OF ty_url,
         regex       TYPE string,
         group_names TYPE STANDARD TABLE OF seosconame WITH DEFAULT KEY,
       END OF ty_url .
-  types:
-    BEGIN OF ty_response,
+    TYPES:
+      BEGIN OF ty_response,
         remove_data_object TYPE abap_bool,
       END OF ty_response .
-  types:
-    BEGIN OF ty_meta,
+    TYPES:
+      BEGIN OF ty_meta,
         summary           TYPE string,
         url               TYPE ty_url,
         method            TYPE string,
@@ -24,118 +24,118 @@ public section.
         tags              TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
         response_settings TYPE ty_response,
       END OF ty_meta .
-  types:
-    BEGIN OF ty_meta_internal,
+    TYPES:
+      BEGIN OF ty_meta_internal,
         meta       TYPE ty_meta,
         obj        TYPE REF TO object,
         parameters TYPE ty_parameters_tt,
         classname  TYPE seoclsname,
       END OF ty_meta_internal .
-  types:
-    ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
-  types:
-    ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
-  types:
-    BEGIN OF ty_externaldoc,
+    TYPES:
+      ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
+    TYPES:
+      ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
+    TYPES:
+      BEGIN OF ty_externaldoc,
         description TYPE string,
         url         TYPE string,
       END OF ty_externaldoc .
-  types:
-    BEGIN OF ty_tagdescription,
+    TYPES:
+      BEGIN OF ty_tagdescription,
         tag         TYPE string,
         description TYPE string,
         externaldoc TYPE ty_externaldoc,
       END OF ty_tagdescription .
-  types:
-    ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
+    TYPES:
+      ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
 
-  constants:
-    BEGIN OF c_parm_kind,
+    CONSTANTS:
+      BEGIN OF c_parm_kind,
         importing TYPE seopardecl VALUE '0',
         exporting TYPE seopardecl VALUE '1',
         changing  TYPE seopardecl VALUE '2',
         returning TYPE seopardecl VALUE '3',
       END OF c_parm_kind .
-  constants:
-    BEGIN OF c_method,
+    CONSTANTS:
+      BEGIN OF c_method,
         get    TYPE string VALUE 'GET',
         post   TYPE string VALUE 'POST',
         put    TYPE string VALUE 'PUT',
         delete TYPE string VALUE 'DELETE',
       END OF c_method .
 
-  methods CONSTRUCTOR
-    importing
-      !II_SERVER type ref to IF_HTTP_SERVER
-      !IV_BASE type STRING
-      !IV_SWAGGER_JSON type STRING default '/swagger.json'
-      !IV_SWAGGER_HTML type STRING default '/swagger.html'
-      !IV_TITLE type STRING .
-  methods REGISTER
-    importing
-      !II_HANDLER type ref to ZIF_SWAG_HANDLER .
-  methods RUN
-    raising
-      CX_STATIC_CHECK .
-  methods SET_TAGDESCRIPTION
-    importing
-      !IV_TAG type STRING
-      !IV_DESCRIPTION type STRING
-      !IV_EXTERNALDOC type TY_EXTERNALDOC optional .
-protected section.
+    METHODS constructor
+      IMPORTING
+        !ii_server       TYPE REF TO if_http_server
+        !iv_base         TYPE string
+        !iv_swagger_json TYPE string DEFAULT '/swagger.json'
+        !iv_swagger_html TYPE string DEFAULT '/swagger.html'
+        !iv_title        TYPE string .
+    METHODS register
+      IMPORTING
+        !ii_handler TYPE REF TO zif_swag_handler .
+    METHODS run
+      RAISING
+        cx_static_check .
+    METHODS set_tagdescription
+      IMPORTING
+        !iv_tag         TYPE string
+        !iv_description TYPE string
+        !iv_externaldoc TYPE ty_externaldoc OPTIONAL .
+  PROTECTED SECTION.
 
-  data MV_BASE type STRING .
-  data MI_SERVER type ref to IF_HTTP_SERVER .
-  data MT_META type TY_META_INTERNAL_TT .
-  data MT_TAGDESCRIPTION type TY_TAGDESCRIPTION_TT .
-  data MV_SWAGGER_JSON type STRING .
-  data MV_SWAGGER_HTML type STRING .
-  data MV_TITLE type STRING .
+    DATA mv_base TYPE string .
+    DATA mi_server TYPE REF TO if_http_server .
+    DATA mt_meta TYPE ty_meta_internal_tt .
+    DATA mt_tagdescription TYPE ty_tagdescription_tt .
+    DATA mv_swagger_json TYPE string .
+    DATA mv_swagger_html TYPE string .
+    DATA mv_title TYPE string .
 
-  methods BUILD_PARAMETERS
-    importing
-      !IS_META type TY_META_INTERNAL
-    returning
-      value(RT_PARAMETERS) type ABAP_PARMBIND_TAB .
-  methods CREATE_DATA
-    importing
-      !IS_META type TY_META_INTERNAL
-    returning
-      value(RR_DATA) type ref to DATA .
-  methods FROM_BODY
-    importing
-      !IS_META type TY_META_INTERNAL
-      !IR_REF type ref to DATA .
-  methods FROM_QUERY
-    importing
-      !IS_META type TY_META_INTERNAL
-      !IR_REF type ref to DATA .
-  methods FROM_PATH
-    importing
-      !IS_META type TY_META_INTERNAL
-      !IR_REF type ref to DATA .
-  methods GENERATE_SPEC
-    importing
-      !IV_TITLE type CLIKE
-      !IV_DESCRIPTION type CLIKE .
-  methods GENERATE_UI
-    importing
-      !IV_JSON_URL type STRING
-      !IV_DIST type STRING default ''
-      !IV_TITLE type CLIKE default ''
-    returning
-      value(RV_UI) type STRING .
-  methods JSON_REPLY
-    importing
-      !IS_META type TY_META_INTERNAL
-      !IT_PARAMETERS type ABAP_PARMBIND_TAB .
-  methods TEXT_REPLY
-    importing
-      !IS_META type TY_META_INTERNAL
-      !IT_PARAMETERS type ABAP_PARMBIND_TAB .
-  methods VALIDATE_PARAMETERS
-    importing
-      !IT_PARAMETERS type TY_PARAMETERS_TT .
+    METHODS build_parameters
+      IMPORTING
+        !is_meta             TYPE ty_meta_internal
+      RETURNING
+        VALUE(rt_parameters) TYPE abap_parmbind_tab .
+    METHODS create_data
+      IMPORTING
+        !is_meta       TYPE ty_meta_internal
+      RETURNING
+        VALUE(rr_data) TYPE REF TO data .
+    METHODS from_body
+      IMPORTING
+        !is_meta TYPE ty_meta_internal
+        !ir_ref  TYPE REF TO data .
+    METHODS from_query
+      IMPORTING
+        !is_meta TYPE ty_meta_internal
+        !ir_ref  TYPE REF TO data .
+    METHODS from_path
+      IMPORTING
+        !is_meta TYPE ty_meta_internal
+        !ir_ref  TYPE REF TO data .
+    METHODS generate_spec
+      IMPORTING
+        !iv_title       TYPE clike
+        !iv_description TYPE clike .
+    METHODS generate_ui
+      IMPORTING
+        !iv_json_url TYPE string
+        !iv_dist     TYPE string DEFAULT ''
+        !iv_title    TYPE clike DEFAULT ''
+      RETURNING
+        VALUE(rv_ui) TYPE string .
+    METHODS json_reply
+      IMPORTING
+        !is_meta       TYPE ty_meta_internal
+        !it_parameters TYPE abap_parmbind_tab .
+    METHODS text_reply
+      IMPORTING
+        !is_meta       TYPE ty_meta_internal
+        !it_parameters TYPE abap_parmbind_tab .
+    METHODS validate_parameters
+      IMPORTING
+        !it_parameters TYPE ty_parameters_tt .
   PRIVATE SECTION.
     METHODS handle_response
       IMPORTING

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -1,30 +1,22 @@
-CLASS zcl_swag DEFINITION
-  PUBLIC
-  CREATE PUBLIC .
+class ZCL_SWAG definition
+  public
+  create public .
 
-  PUBLIC SECTION.
+public section.
 
-    CONSTANTS:
-      BEGIN OF c_parm_kind,
-        importing TYPE seopardecl VALUE '0',
-        exporting TYPE seopardecl VALUE '1',
-        changing  TYPE seopardecl VALUE '2',
-        returning TYPE seopardecl VALUE '3',
-      END OF c_parm_kind .
-
-    TYPES:
-      ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
-    TYPES:
-      BEGIN OF ty_url,
+  types:
+    ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
+  types:
+    BEGIN OF ty_url,
         regex       TYPE string,
         group_names TYPE STANDARD TABLE OF seosconame WITH DEFAULT KEY,
       END OF ty_url .
-    TYPES:
-      BEGIN OF ty_response,
+  types:
+    BEGIN OF ty_response,
         remove_data_object TYPE abap_bool,
-      END OF ty_response.
-    TYPES:
-      BEGIN OF ty_meta,
+      END OF ty_response .
+  types:
+    BEGIN OF ty_meta,
         summary           TYPE string,
         url               TYPE ty_url,
         method            TYPE string,
@@ -32,92 +24,115 @@ CLASS zcl_swag DEFINITION
         tags              TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
         response_settings TYPE ty_response,
       END OF ty_meta .
-    TYPES:
-      BEGIN OF ty_meta_internal,
+  types:
+    BEGIN OF ty_meta_internal,
         meta       TYPE ty_meta,
         obj        TYPE REF TO object,
         parameters TYPE ty_parameters_tt,
         classname  TYPE seoclsname,
       END OF ty_meta_internal .
-    TYPES:
-      ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
-    TYPES:
-      ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
+  types:
+    ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
+  types:
+    ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
+  types:
+    BEGIN OF ty_tagdescription,
+        tag               TYPE string,
+        description       TYPE string,
+        externaldocsdescr TYPE string,
+        externaldocsurl   TYPE string,
+      END OF ty_tagdescription .
+  types:
+    ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
 
-    CONSTANTS:
-      BEGIN OF c_method,
+  constants:
+    BEGIN OF c_parm_kind,
+        importing TYPE seopardecl VALUE '0',
+        exporting TYPE seopardecl VALUE '1',
+        changing  TYPE seopardecl VALUE '2',
+        returning TYPE seopardecl VALUE '3',
+      END OF c_parm_kind .
+  constants:
+    BEGIN OF c_method,
         get    TYPE string VALUE 'GET',
         post   TYPE string VALUE 'POST',
         put    TYPE string VALUE 'PUT',
         delete TYPE string VALUE 'DELETE',
       END OF c_method .
 
-    METHODS constructor
-      IMPORTING
-        !ii_server       TYPE REF TO if_http_server
-        !iv_base         TYPE string
-        !iv_swagger_json TYPE string DEFAULT '/swagger.json'
-        !iv_swagger_html TYPE string DEFAULT '/swagger.html'
-        !iv_title        TYPE string .
-    METHODS register
-      IMPORTING
-        !ii_handler TYPE REF TO zif_swag_handler .
-    METHODS run
-      RAISING
-        cx_static_check .
-  PROTECTED SECTION.
+  methods CONSTRUCTOR
+    importing
+      !II_SERVER type ref to IF_HTTP_SERVER
+      !IV_BASE type STRING
+      !IV_SWAGGER_JSON type STRING default '/swagger.json'
+      !IV_SWAGGER_HTML type STRING default '/swagger.html'
+      !IV_TITLE type STRING .
+  methods REGISTER
+    importing
+      !II_HANDLER type ref to ZIF_SWAG_HANDLER .
+  methods RUN
+    raising
+      CX_STATIC_CHECK .
+  methods SET_TAGDESCRIPTION
+    importing
+      !IV_TAG type STRING
+      !IV_DESCRIPTION type STRING
+      !IV_EXTERNALDOCSDESCR type STRING optional
+      !IV_EXTERNALDOCSURL type STRING optional .
+protected section.
 
-    DATA mv_base TYPE string .
-    DATA mi_server TYPE REF TO if_http_server .
-    DATA mt_meta TYPE ty_meta_internal_tt .
-    DATA mv_swagger_json TYPE string .
-    DATA mv_swagger_html TYPE string .
-    DATA mv_title TYPE string .
+  data MV_BASE type STRING .
+  data MI_SERVER type ref to IF_HTTP_SERVER .
+  data MT_META type TY_META_INTERNAL_TT .
+  data MT_TAGDESCRIPTION type TY_TAGDESCRIPTION_TT .
+  data MV_SWAGGER_JSON type STRING .
+  data MV_SWAGGER_HTML type STRING .
+  data MV_TITLE type STRING .
 
-    METHODS build_parameters
-      IMPORTING
-        !is_meta             TYPE ty_meta_internal
-      RETURNING
-        VALUE(rt_parameters) TYPE abap_parmbind_tab .
-    METHODS create_data
-      IMPORTING
-        !is_meta       TYPE ty_meta_internal
-      RETURNING
-        VALUE(rr_data) TYPE REF TO data .
-    METHODS from_body
-      IMPORTING
-        !is_meta TYPE ty_meta_internal
-        !ir_ref  TYPE REF TO data .
-    METHODS from_query
-      IMPORTING
-        !is_meta TYPE ty_meta_internal
-        !ir_ref  TYPE REF TO data .
-    METHODS from_path
-      IMPORTING
-        !is_meta TYPE ty_meta_internal
-        !ir_ref  TYPE REF TO data .
-    METHODS generate_spec
-      IMPORTING
-        !iv_title       TYPE clike
-        !iv_description TYPE clike .
-    METHODS generate_ui
-      IMPORTING
-        !iv_json_url TYPE string
-        !iv_dist     TYPE string DEFAULT ''
-        !iv_title    TYPE clike DEFAULT ''
-      RETURNING
-        VALUE(rv_ui) TYPE string .
-    METHODS json_reply
-      IMPORTING
-        !is_meta       TYPE ty_meta_internal
-        !it_parameters TYPE abap_parmbind_tab .
-    METHODS text_reply
-      IMPORTING
-        !is_meta       TYPE ty_meta_internal
-        !it_parameters TYPE abap_parmbind_tab .
-    METHODS validate_parameters
-      IMPORTING
-        !it_parameters TYPE ty_parameters_tt .
+  methods BUILD_PARAMETERS
+    importing
+      !IS_META type TY_META_INTERNAL
+    returning
+      value(RT_PARAMETERS) type ABAP_PARMBIND_TAB .
+  methods CREATE_DATA
+    importing
+      !IS_META type TY_META_INTERNAL
+    returning
+      value(RR_DATA) type ref to DATA .
+  methods FROM_BODY
+    importing
+      !IS_META type TY_META_INTERNAL
+      !IR_REF type ref to DATA .
+  methods FROM_QUERY
+    importing
+      !IS_META type TY_META_INTERNAL
+      !IR_REF type ref to DATA .
+  methods FROM_PATH
+    importing
+      !IS_META type TY_META_INTERNAL
+      !IR_REF type ref to DATA .
+  methods GENERATE_SPEC
+    importing
+      !IV_TITLE type CLIKE
+      !IV_DESCRIPTION type CLIKE .
+  methods GENERATE_UI
+    importing
+      !IV_JSON_URL type STRING
+      !IV_DIST type STRING default ''
+      !IV_TITLE type CLIKE default ''
+    returning
+      value(RV_UI) type STRING .
+  methods JSON_REPLY
+    importing
+      !IS_META type TY_META_INTERNAL
+      !IT_PARAMETERS type ABAP_PARMBIND_TAB .
+  methods TEXT_REPLY
+    importing
+      !IS_META type TY_META_INTERNAL
+      !IT_PARAMETERS type ABAP_PARMBIND_TAB .
+  methods VALIDATE_PARAMETERS
+    importing
+      !IT_PARAMETERS type TY_PARAMETERS_TT .
   PRIVATE SECTION.
     METHODS handle_response
       IMPORTING
@@ -144,7 +159,7 @@ ENDCLASS.
 
 
 
-CLASS zcl_swag IMPLEMENTATION.
+CLASS ZCL_SWAG IMPLEMENTATION.
 
 
   METHOD build_parameters.
@@ -353,10 +368,11 @@ CLASS zcl_swag IMPLEMENTATION.
 
     CREATE OBJECT lo_spec
       EXPORTING
-        iv_title       = iv_title
-        iv_description = iv_description
-        it_meta        = mt_meta
-        iv_base        = mv_base.
+        iv_title          = iv_title
+        iv_description    = iv_description
+        it_meta           = mt_meta
+        iv_base           = mv_base
+        it_tagdescription = mt_tagdescription.
 
     lv_spec = lo_spec->generate( ).
 
@@ -434,6 +450,51 @@ CLASS zcl_swag IMPLEMENTATION.
 
     mi_server->response->set_cdata( rv_ui ).
     mi_server->response->set_status( code = 200 reason = '200' ).
+
+  ENDMETHOD.
+
+
+  METHOD handle_remove_data_object.
+
+    DATA lv_length TYPE i.
+    DATA lv_minus_data TYPE i.
+
+    IF is_meta-meta-response_settings-remove_data_object = abap_true.
+
+      lv_length = strlen( cv_data_as_string ).
+      lv_minus_data = lv_length - 9.
+
+      "start has |{"DATA":| (8) end has |}| (1)
+      cv_data_as_string = cv_data_as_string+8(lv_minus_data).
+
+    ENDIF.
+
+  ENDMETHOD.
+
+
+  METHOD handle_response.
+
+    DATA:
+      lo_xstring_to_string TYPE REF TO cl_abap_conv_in_ce,
+      lo_string_to_xstring TYPE REF TO cl_abap_conv_out_ce,
+      lv_data_as_string    TYPE string.
+
+    lo_xstring_to_string = cl_abap_conv_in_ce=>create( input = cv_data ).
+    lo_xstring_to_string->read( IMPORTING data = lv_data_as_string ).
+
+    handle_remove_data_object(
+          EXPORTING
+            is_meta = is_meta
+          CHANGING
+            cv_data_as_string = lv_data_as_string ).
+
+    lo_string_to_xstring = cl_abap_conv_out_ce=>create( ).
+    lo_string_to_xstring->convert(
+      EXPORTING
+          data = lv_data_as_string
+      IMPORTING
+          buffer = cv_data ).
+
 
   ENDMETHOD.
 
@@ -593,6 +654,17 @@ CLASS zcl_swag IMPLEMENTATION.
   ENDMETHOD.
 
 
+  METHOD set_tagdescription.
+
+    APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<tagdescription>).
+    <tagdescription>-tag = iv_tag.
+    <tagdescription>-description = iv_description.
+    <tagdescription>-externaldocsdescr = iv_externaldocsdescr.
+    <tagdescription>-externaldocsurl = iv_externaldocsurl.
+
+  ENDMETHOD.
+
+
   METHOD text_reply.
 
     FIELD-SYMBOLS: <lg_any>       TYPE any,
@@ -637,49 +709,4 @@ CLASS zcl_swag IMPLEMENTATION.
 * todo, max one importing parameter? apart from path parameters?
 
   ENDMETHOD.
-
-  METHOD handle_response.
-
-    DATA:
-      lo_xstring_to_string TYPE REF TO cl_abap_conv_in_ce,
-      lo_string_to_xstring TYPE REF TO cl_abap_conv_out_ce,
-      lv_data_as_string    TYPE string.
-
-    lo_xstring_to_string = cl_abap_conv_in_ce=>create( input = cv_data ).
-    lo_xstring_to_string->read( IMPORTING data = lv_data_as_string ).
-
-    handle_remove_data_object(
-          EXPORTING
-            is_meta = is_meta
-          CHANGING
-            cv_data_as_string = lv_data_as_string ).
-
-    lo_string_to_xstring = cl_abap_conv_out_ce=>create( ).
-    lo_string_to_xstring->convert(
-      EXPORTING
-          data = lv_data_as_string
-      IMPORTING
-          buffer = cv_data ).
-
-
-  ENDMETHOD.
-
-
-  METHOD handle_remove_data_object.
-
-    DATA lv_length TYPE i.
-    DATA lv_minus_data TYPE i.
-
-    IF is_meta-meta-response_settings-remove_data_object = abap_true.
-
-      lv_length = strlen( cv_data_as_string ).
-      lv_minus_data = lv_length - 9.
-
-      "start has |{"DATA":| (8) end has |}| (1)
-      cv_data_as_string = cv_data_as_string+8(lv_minus_data).
-
-    ENDIF.
-
-  ENDMETHOD.
-
 ENDCLASS.

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -36,11 +36,15 @@ public section.
   types:
     ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
   types:
+    BEGIN OF ty_externaldoc,
+        description TYPE string,
+        url         TYPE string,
+      END OF ty_externaldoc .
+  types:
     BEGIN OF ty_tagdescription,
-        tag               TYPE string,
-        description       TYPE string,
-        externaldocsdescr TYPE string,
-        externaldocsurl   TYPE string,
+        tag         TYPE string,
+        description TYPE string,
+        externaldoc TYPE ty_externaldoc,
       END OF ty_tagdescription .
   types:
     ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
@@ -77,8 +81,7 @@ public section.
     importing
       !IV_TAG type STRING
       !IV_DESCRIPTION type STRING
-      !IV_EXTERNALDOCSDESCR type STRING optional
-      !IV_EXTERNALDOCSURL type STRING optional .
+      !IV_EXTERNALDOC type TY_EXTERNALDOC optional .
 protected section.
 
   data MV_BASE type STRING .
@@ -659,8 +662,8 @@ CLASS ZCL_SWAG IMPLEMENTATION.
     APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<tagdescription>).
     <tagdescription>-tag = iv_tag.
     <tagdescription>-description = iv_description.
-    <tagdescription>-externaldocsdescr = iv_externaldocsdescr.
-    <tagdescription>-externaldocsurl = iv_externaldocsurl.
+    <tagdescription>-externaldoc-description = iv_externaldoc-description.
+    <tagdescription>-externaldoc-url = iv_externaldoc-url.
 
   ENDMETHOD.
 

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -657,11 +657,7 @@ CLASS ZCL_SWAG IMPLEMENTATION.
 
   METHOD set_tagdescription.
 
-    APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<ls_tagdescription>).
-    <ls_tagdescription>-tag = is_description-tag.
-    <ls_tagdescription>-description = is_description-description.
-    <ls_tagdescription>-externaldoc-description = is_description-externaldoc-description.
-    <ls_tagdescription>-externaldoc-url = is_description-externaldoc-url.
+    APPEND is_description TO mt_tagdescription.
 
   ENDMETHOD.
 

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -1,22 +1,22 @@
-CLASS zcl_swag DEFINITION
-  PUBLIC
-  CREATE PUBLIC .
+class ZCL_SWAG definition
+  public
+  create public .
 
-  PUBLIC SECTION.
+public section.
 
-    TYPES:
-      ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
-    TYPES:
-      BEGIN OF ty_url,
+  types:
+    ty_parameters_tt TYPE STANDARD TABLE OF seosubcodf WITH DEFAULT KEY .
+  types:
+    BEGIN OF ty_url,
         regex       TYPE string,
         group_names TYPE STANDARD TABLE OF seosconame WITH DEFAULT KEY,
       END OF ty_url .
-    TYPES:
-      BEGIN OF ty_response,
+  types:
+    BEGIN OF ty_response,
         remove_data_object TYPE abap_bool,
       END OF ty_response .
-    TYPES:
-      BEGIN OF ty_meta,
+  types:
+    BEGIN OF ty_meta,
         summary           TYPE string,
         url               TYPE ty_url,
         method            TYPE string,
@@ -24,64 +24,62 @@ CLASS zcl_swag DEFINITION
         tags              TYPE STANDARD TABLE OF string WITH DEFAULT KEY,
         response_settings TYPE ty_response,
       END OF ty_meta .
-    TYPES:
-      BEGIN OF ty_meta_internal,
+  types:
+    BEGIN OF ty_meta_internal,
         meta       TYPE ty_meta,
         obj        TYPE REF TO object,
         parameters TYPE ty_parameters_tt,
         classname  TYPE seoclsname,
       END OF ty_meta_internal .
-    TYPES:
-      ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
-    TYPES:
-      ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
-    TYPES:
-      BEGIN OF ty_externaldoc,
+  types:
+    ty_meta_internal_tt TYPE STANDARD TABLE OF ty_meta_internal WITH DEFAULT KEY .
+  types:
+    ty_meta_tt TYPE STANDARD TABLE OF ty_meta WITH DEFAULT KEY .
+  types:
+    BEGIN OF ty_externaldoc,
         description TYPE string,
         url         TYPE string,
       END OF ty_externaldoc .
-    TYPES:
-      BEGIN OF ty_tagdescription,
+  types:
+    BEGIN OF ty_tagdescription,
         tag         TYPE string,
         description TYPE string,
         externaldoc TYPE ty_externaldoc,
       END OF ty_tagdescription .
-    TYPES:
-      ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
+  types:
+    ty_tagdescription_tt TYPE STANDARD TABLE OF ty_tagdescription WITH DEFAULT KEY .
 
-    CONSTANTS:
-      BEGIN OF c_parm_kind,
+  constants:
+    BEGIN OF c_parm_kind,
         importing TYPE seopardecl VALUE '0',
         exporting TYPE seopardecl VALUE '1',
         changing  TYPE seopardecl VALUE '2',
         returning TYPE seopardecl VALUE '3',
       END OF c_parm_kind .
-    CONSTANTS:
-      BEGIN OF c_method,
+  constants:
+    BEGIN OF c_method,
         get    TYPE string VALUE 'GET',
         post   TYPE string VALUE 'POST',
         put    TYPE string VALUE 'PUT',
         delete TYPE string VALUE 'DELETE',
       END OF c_method .
 
-    METHODS constructor
-      IMPORTING
-        !ii_server       TYPE REF TO if_http_server
-        !iv_base         TYPE string
-        !iv_swagger_json TYPE string DEFAULT '/swagger.json'
-        !iv_swagger_html TYPE string DEFAULT '/swagger.html'
-        !iv_title        TYPE string .
-    METHODS register
-      IMPORTING
-        !ii_handler TYPE REF TO zif_swag_handler .
-    METHODS run
-      RAISING
-        cx_static_check .
-    METHODS set_tagdescription
-      IMPORTING
-        !iv_tag         TYPE string
-        !iv_description TYPE string
-        !iv_externaldoc TYPE ty_externaldoc OPTIONAL .
+  methods CONSTRUCTOR
+    importing
+      !II_SERVER type ref to IF_HTTP_SERVER
+      !IV_BASE type STRING
+      !IV_SWAGGER_JSON type STRING default '/swagger.json'
+      !IV_SWAGGER_HTML type STRING default '/swagger.html'
+      !IV_TITLE type STRING .
+  methods REGISTER
+    importing
+      !II_HANDLER type ref to ZIF_SWAG_HANDLER .
+  methods RUN
+    raising
+      CX_STATIC_CHECK .
+  methods SET_TAGDESCRIPTION
+    importing
+      !IS_DESCRIPTION type TY_TAGDESCRIPTION .
   PROTECTED SECTION.
 
     DATA mv_base TYPE string .
@@ -660,10 +658,10 @@ CLASS ZCL_SWAG IMPLEMENTATION.
   METHOD set_tagdescription.
 
     APPEND INITIAL LINE TO mt_tagdescription ASSIGNING FIELD-SYMBOL(<ls_tagdescription>).
-    <ls_tagdescription>-tag = iv_tag.
-    <ls_tagdescription>-description = iv_description.
-    <ls_tagdescription>-externaldoc-description = iv_externaldoc-description.
-    <ls_tagdescription>-externaldoc-url = iv_externaldoc-url.
+    <ls_tagdescription>-tag = is_description-tag.
+    <ls_tagdescription>-description = is_description-description.
+    <ls_tagdescription>-externaldoc-description = is_description-externaldoc-description.
+    <ls_tagdescription>-externaldoc-url = is_description-externaldoc-url.
 
   ENDMETHOD.
 

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -1,48 +1,53 @@
-CLASS zcl_swag_spec DEFINITION
-  PUBLIC
-  CREATE PUBLIC .
+class ZCL_SWAG_SPEC definition
+  public
+  create public .
 
-  PUBLIC SECTION.
+public section.
 
-    METHODS constructor
-      IMPORTING
-        !iv_title       TYPE clike
-        !iv_description TYPE clike
-        !it_meta        TYPE zcl_swag=>ty_meta_internal_tt
-        !iv_base        TYPE clike .
-    METHODS generate
-      RETURNING
-        VALUE(rv_spec) TYPE string .
-  PROTECTED SECTION.
+  methods CONSTRUCTOR
+    importing
+      !IV_TITLE type CLIKE
+      !IV_DESCRIPTION type CLIKE
+      !IT_META type ZCL_SWAG=>TY_META_INTERNAL_TT
+      !IV_BASE type CLIKE
+      !IT_TAGDESCRIPTION type ZCL_SWAG=>TY_TAGDESCRIPTION_TT .
+  methods GENERATE
+    returning
+      value(RV_SPEC) type STRING .
+protected section.
 
-    DATA mv_title TYPE string .
-    DATA mv_description TYPE string .
-    DATA mt_meta TYPE zcl_swag=>ty_meta_internal_tt .
-    DATA mv_base TYPE string .
-    DATA mt_definitions TYPE string_table .
+  data MV_TITLE type STRING .
+  data MV_DESCRIPTION type STRING .
+  data MT_META type ZCL_SWAG=>TY_META_INTERNAL_TT .
+  data MV_BASE type STRING .
+  data MT_DEFINITIONS type STRING_TABLE .
+  data MT_TAGDESCRIPTION type ZCL_SWAG=>TY_TAGDESCRIPTION_TT .
 
-    METHODS request
-      IMPORTING
-        !is_meta      TYPE zcl_swag=>ty_meta_internal
-        !is_parameter TYPE seosubcodf .
-    METHODS definitions
-      RETURNING
-        VALUE(rv_defs) TYPE string .
-    METHODS path
-      IMPORTING
-        !is_meta       TYPE zcl_swag=>ty_meta_internal
-      RETURNING
-        VALUE(rv_path) TYPE string .
-    METHODS parameters
-      IMPORTING
-        !is_meta             TYPE zcl_swag=>ty_meta_internal
-      RETURNING
-        VALUE(rv_parameters) TYPE string .
-    METHODS response
-      IMPORTING
-        !is_meta           TYPE zcl_swag=>ty_meta_internal
-      RETURNING
-        VALUE(rv_response) TYPE string .
+  methods REQUEST
+    importing
+      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
+      !IS_PARAMETER type SEOSUBCODF .
+  methods DEFINITIONS
+    returning
+      value(RV_DEFS) type STRING .
+  methods PATH
+    importing
+      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
+    returning
+      value(RV_PATH) type STRING .
+  methods PARAMETERS
+    importing
+      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
+    returning
+      value(RV_PARAMETERS) type STRING .
+  methods RESPONSE
+    importing
+      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
+    returning
+      value(RV_RESPONSE) type STRING .
+  methods TAGDESCRIPTIONS
+    returning
+      value(RV_DEFS) type STRING .
   PRIVATE SECTION.
 ENDCLASS.
 
@@ -57,6 +62,7 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
     mv_description = iv_description.
     mt_meta        = it_meta.
     mv_base        = iv_base.
+    mt_tagdescription = it_tagdescription.
 
   ENDMETHOD.
 
@@ -219,6 +225,9 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
 
     _add '  },'.
 
+    lv_add = tagdescriptions( ).
+    _add lv_add.
+
     lv_add = definitions( ).
     _add lv_add.
 
@@ -376,6 +385,47 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
 
     CONCATENATE LINES OF lt_string INTO rv_response
       SEPARATED BY cl_abap_char_utilities=>newline.
+
+  ENDMETHOD.
+
+
+  METHOD tagdescriptions.
+
+    DATA: lv_string TYPE string,
+          lv_sep    TYPE string,
+          lt_string TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
+
+    FIELD-SYMBOLS: <tagdescription> LIKE LINE OF mt_tagdescription.
+
+
+    IF mt_tagdescription IS NOT INITIAL.
+
+      APPEND '  "tags": [ {' TO lt_string.
+
+      LOOP AT mt_tagdescription ASSIGNING <tagdescription>.
+        CONCATENATE '"name":"' <tagdescription>-tag '",' INTO lv_string.
+        APPEND lv_string TO lt_string.
+        CONCATENATE '"description":"' <tagdescription>-description '"' INTO lv_string.
+        APPEND lv_string TO lt_string.
+        APPEND ',' TO lt_string.
+        IF <tagdescription>-externaldocsdescr IS NOT INITIAL.
+          CONCATENATE '"externalDocs": { "description":"' <tagdescription>-externaldocsdescr '",' INTO lv_string.
+          APPEND lv_string TO lt_string.
+          CONCATENATE '"url":"' <tagdescription>-externaldocsurl '" }' INTO lv_string.
+          APPEND lv_string TO lt_string.
+          APPEND ',' TO lt_string.
+        ENDIF.
+      ENDLOOP.
+      IF sy-subrc = 0.
+* fix the comma
+        DELETE lt_string INDEX lines( lt_string ).
+        APPEND '} ],' TO lt_string.
+      ENDIF.
+
+      CONCATENATE LINES OF lt_string INTO rv_defs
+        SEPARATED BY cl_abap_char_utilities=>newline.
+
+    ENDIF.
 
   ENDMETHOD.
 ENDCLASS.

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -93,7 +93,8 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
   METHOD generate.
 
     DEFINE _add.
-      CONCATENATE rv_spec &1 cl_abap_char_utilities=>newline INTO rv_spec ##NO_TEXT.
+      CONCATENATE rv_spec &1 cl_abap_char_utilities=>newline
+         INTO rv_spec ##NO_TEXT.
     END-OF-DEFINITION.
 
     TYPES: BEGIN OF ty_path,
@@ -110,7 +111,6 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
 
     FIELD-SYMBOLS: <ls_path> LIKE LINE OF lt_paths,
                    <ls_meta> LIKE LINE OF mt_meta.
-
 
 * handle path with multiple handlers(ie. GET and POST)
     LOOP AT mt_meta ASSIGNING <ls_meta>.
@@ -221,15 +221,11 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
         _add ','.
       ENDIF.
     ENDLOOP.
-
     _add '  },'.
-
     lv_add = tagdescriptions( ).
     _add lv_add.
-
     lv_add = definitions( ).
     _add lv_add.
-
     _add '}'.
 
   ENDMETHOD.

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -67,6 +67,8 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
           lv_sep    TYPE string,
           lt_string TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
 
+    SORT mt_definitions.
+    DELETE ADJACENT DUPLICATES FROM mt_definitions.
 
     APPEND '  "definitions":{' TO lt_string.
 
@@ -362,11 +364,11 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
       lv_type = lo_map->map( ).
 
       APPEND '"schema": {' TO lt_string.
-      lv_string = |"$ref": "#/definitions/{ is_meta-meta-handler }_Response"|.
+      lv_string = |"$ref": "#/definitions/{ <ls_parameter>-type }"|.
       APPEND lv_string TO lt_string.
       APPEND '}' TO lt_string.
 
-      lv_string = |"{ is_meta-meta-handler }_Response":\{"type": "object","properties": \{"DATA": \{{ lv_type }\}\}\}|.
+      lv_string = |"{ <ls_parameter>-type }":\{"type": "object","properties": \{"DATA": \{{ lv_type }\}\}\}|.
       APPEND lv_string TO mt_definitions.
     ENDLOOP.
 

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -408,10 +408,10 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
         CONCATENATE '"description":"' <tagdescription>-description '"' INTO lv_string.
         APPEND lv_string TO lt_string.
         APPEND ',' TO lt_string.
-        IF <tagdescription>-externaldocsdescr IS NOT INITIAL.
-          CONCATENATE '"externalDocs": { "description":"' <tagdescription>-externaldocsdescr '",' INTO lv_string.
+        IF <tagdescription>-externaldoc IS NOT INITIAL.
+          CONCATENATE '"externalDocs": { "description":"' <tagdescription>-externaldoc-description '",' INTO lv_string.
           APPEND lv_string TO lt_string.
-          CONCATENATE '"url":"' <tagdescription>-externaldocsurl '" }' INTO lv_string.
+          CONCATENATE '"url":"' <tagdescription>-externaldoc-url '" }' INTO lv_string.
           APPEND lv_string TO lt_string.
           APPEND ',' TO lt_string.
         ENDIF.

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -1,53 +1,53 @@
-class ZCL_SWAG_SPEC definition
-  public
-  create public .
+CLASS zcl_swag_spec DEFINITION
+  PUBLIC
+  CREATE PUBLIC .
 
-public section.
+  PUBLIC SECTION.
 
-  methods CONSTRUCTOR
-    importing
-      !IV_TITLE type CLIKE
-      !IV_DESCRIPTION type CLIKE
-      !IT_META type ZCL_SWAG=>TY_META_INTERNAL_TT
-      !IV_BASE type CLIKE
-      !IT_TAGDESCRIPTION type ZCL_SWAG=>TY_TAGDESCRIPTION_TT .
-  methods GENERATE
-    returning
-      value(RV_SPEC) type STRING .
-protected section.
+    METHODS constructor
+      IMPORTING
+        !iv_title          TYPE clike
+        !iv_description    TYPE clike
+        !it_meta           TYPE zcl_swag=>ty_meta_internal_tt
+        !iv_base           TYPE clike
+        !it_tagdescription TYPE zcl_swag=>ty_tagdescription_tt .
+    METHODS generate
+      RETURNING
+        VALUE(rv_spec) TYPE string .
+  PROTECTED SECTION.
 
-  data MV_TITLE type STRING .
-  data MV_DESCRIPTION type STRING .
-  data MT_META type ZCL_SWAG=>TY_META_INTERNAL_TT .
-  data MV_BASE type STRING .
-  data MT_DEFINITIONS type STRING_TABLE .
-  data MT_TAGDESCRIPTION type ZCL_SWAG=>TY_TAGDESCRIPTION_TT .
+    DATA mv_title TYPE string .
+    DATA mv_description TYPE string .
+    DATA mt_meta TYPE zcl_swag=>ty_meta_internal_tt .
+    DATA mv_base TYPE string .
+    DATA mt_definitions TYPE string_table .
+    DATA mt_tagdescription TYPE zcl_swag=>ty_tagdescription_tt .
 
-  methods REQUEST
-    importing
-      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
-      !IS_PARAMETER type SEOSUBCODF .
-  methods DEFINITIONS
-    returning
-      value(RV_DEFS) type STRING .
-  methods PATH
-    importing
-      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
-    returning
-      value(RV_PATH) type STRING .
-  methods PARAMETERS
-    importing
-      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
-    returning
-      value(RV_PARAMETERS) type STRING .
-  methods RESPONSE
-    importing
-      !IS_META type ZCL_SWAG=>TY_META_INTERNAL
-    returning
-      value(RV_RESPONSE) type STRING .
-  methods TAGDESCRIPTIONS
-    returning
-      value(RV_DEFS) type STRING .
+    METHODS request
+      IMPORTING
+        !is_meta      TYPE zcl_swag=>ty_meta_internal
+        !is_parameter TYPE seosubcodf .
+    METHODS definitions
+      RETURNING
+        VALUE(rv_defs) TYPE string .
+    METHODS path
+      IMPORTING
+        !is_meta       TYPE zcl_swag=>ty_meta_internal
+      RETURNING
+        VALUE(rv_path) TYPE string .
+    METHODS parameters
+      IMPORTING
+        !is_meta             TYPE zcl_swag=>ty_meta_internal
+      RETURNING
+        VALUE(rv_parameters) TYPE string .
+    METHODS response
+      IMPORTING
+        !is_meta           TYPE zcl_swag=>ty_meta_internal
+      RETURNING
+        VALUE(rv_response) TYPE string .
+    METHODS tagdescriptions
+      RETURNING
+        VALUE(rv_defs) TYPE string .
   PRIVATE SECTION.
 ENDCLASS.
 

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -400,9 +400,10 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
 
     IF mt_tagdescription IS NOT INITIAL.
 
-      APPEND '  "tags": [ {' TO lt_string.
+      APPEND '  "tags": [' TO lt_string.
 
       LOOP AT mt_tagdescription ASSIGNING <ls_tagdescription>.
+        APPEND '{' TO lt_string.
         CONCATENATE '"name":"' <ls_tagdescription>-tag '",' INTO lv_string.
         APPEND lv_string TO lt_string.
         CONCATENATE '"description":"' <ls_tagdescription>-description '"' INTO lv_string.
@@ -414,13 +415,14 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
           APPEND lv_string TO lt_string.
           CONCATENATE '"url":"' <ls_tagdescription>-externaldoc-url '" }' INTO lv_string.
           APPEND lv_string TO lt_string.
+          APPEND '}' TO lt_string.
           APPEND ',' TO lt_string.
         ENDIF.
       ENDLOOP.
       IF sy-subrc = 0.
 * fix the comma
         DELETE lt_string INDEX lines( lt_string ).
-        APPEND '} ],' TO lt_string.
+        APPEND '],' TO lt_string.
       ENDIF.
 
       CONCATENATE LINES OF lt_string INTO rv_defs

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -93,8 +93,7 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
   METHOD generate.
 
     DEFINE _add.
-      CONCATENATE rv_spec &1 cl_abap_char_utilities=>newline
-        INTO rv_spec ##NO_TEXT.
+      CONCATENATE rv_spec &1 cl_abap_char_utilities=>newline INTO rv_spec ##NO_TEXT.
     END-OF-DEFINITION.
 
     TYPES: BEGIN OF ty_path,

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -409,7 +409,8 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
         APPEND lv_string TO lt_string.
         APPEND ',' TO lt_string.
         IF <ls_tagdescription>-externaldoc IS NOT INITIAL.
-          CONCATENATE '"externalDocs": { "description":"' <ls_tagdescription>-externaldoc-description '",' INTO lv_string.
+          CONCATENATE '"externalDocs": { "description":"' <ls_tagdescription>-externaldoc-description '",'
+            INTO lv_string.
           APPEND lv_string TO lt_string.
           CONCATENATE '"url":"' <ls_tagdescription>-externaldoc-url '" }' INTO lv_string.
           APPEND lv_string TO lt_string.

--- a/src/zcl_swag_spec.clas.abap
+++ b/src/zcl_swag_spec.clas.abap
@@ -395,23 +395,23 @@ CLASS ZCL_SWAG_SPEC IMPLEMENTATION.
           lv_sep    TYPE string,
           lt_string TYPE STANDARD TABLE OF string WITH DEFAULT KEY.
 
-    FIELD-SYMBOLS: <tagdescription> LIKE LINE OF mt_tagdescription.
+    FIELD-SYMBOLS: <ls_tagdescription> LIKE LINE OF mt_tagdescription.
 
 
     IF mt_tagdescription IS NOT INITIAL.
 
       APPEND '  "tags": [ {' TO lt_string.
 
-      LOOP AT mt_tagdescription ASSIGNING <tagdescription>.
-        CONCATENATE '"name":"' <tagdescription>-tag '",' INTO lv_string.
+      LOOP AT mt_tagdescription ASSIGNING <ls_tagdescription>.
+        CONCATENATE '"name":"' <ls_tagdescription>-tag '",' INTO lv_string.
         APPEND lv_string TO lt_string.
-        CONCATENATE '"description":"' <tagdescription>-description '"' INTO lv_string.
+        CONCATENATE '"description":"' <ls_tagdescription>-description '"' INTO lv_string.
         APPEND lv_string TO lt_string.
         APPEND ',' TO lt_string.
-        IF <tagdescription>-externaldoc IS NOT INITIAL.
-          CONCATENATE '"externalDocs": { "description":"' <tagdescription>-externaldoc-description '",' INTO lv_string.
+        IF <ls_tagdescription>-externaldoc IS NOT INITIAL.
+          CONCATENATE '"externalDocs": { "description":"' <ls_tagdescription>-externaldoc-description '",' INTO lv_string.
           APPEND lv_string TO lt_string.
-          CONCATENATE '"url":"' <tagdescription>-externaldoc-url '" }' INTO lv_string.
+          CONCATENATE '"url":"' <ls_tagdescription>-externaldoc-url '" }' INTO lv_string.
           APPEND lv_string TO lt_string.
           APPEND ',' TO lt_string.
         ENDIF.


### PR DESCRIPTION
Fixes #28 
Tag descriptions can be added with method zcl_swag~set_tagdescription.

The use of externaldocs is optional.

