### PR TITLE
Change content from `text/plain` to `text/html` if swagger service is a sub-element in SICF

### DIFF
--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -597,6 +597,9 @@ CLASS ZCL_SWAG IMPLEMENTATION.
       generate_ui(
         iv_json_url = mv_base && mv_swagger_json
         iv_title    = mv_title && ' - Swagger' ).
+        
+      mi_server->response->set_header_field( name  = 'content-type'
+                                                       value = 'text/html' ).        
       RETURN.
     ELSEIF lv_path = mv_base && mv_swagger_json.
       generate_spec(

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -597,7 +597,6 @@ CLASS ZCL_SWAG IMPLEMENTATION.
       generate_ui(
         iv_json_url = mv_base && mv_swagger_json
         iv_title    = mv_title && ' - Swagger' ).
-        
       mi_server->response->set_header_field( name  = 'content-type'
                                                        value = 'text/html' ).        
       RETURN.

--- a/src/zcl_swag.clas.abap
+++ b/src/zcl_swag.clas.abap
@@ -598,7 +598,7 @@ CLASS ZCL_SWAG IMPLEMENTATION.
         iv_json_url = mv_base && mv_swagger_json
         iv_title    = mv_title && ' - Swagger' ).
       mi_server->response->set_header_field( name  = 'content-type'
-                                                       value = 'text/html' ).        
+                                                       value = 'text/html' ).
       RETURN.
     ELSEIF lv_path = mv_base && mv_swagger_json.
       generate_spec(


### PR DESCRIPTION
If Swagger service is created as a subelement of a REST service, content type by default comes as `text/plain` and Swagger.html source codes are printed on browser. UI won't be displayed. 

Parent service request handler needs to be skipped to trigger Swagger service( since it is a child element ) as below.
 
` me->if_http_extension~lifetime_rc = if_http_extension~co_lifetime_destroy.` 
`  me->if_http_extension~flow_rc = if_http_extension~co_flow_ok_others_mand`

Above codes will skip REST handler to be destroyed and child handlers to be triggered. Once Swagger handler is triggered, output can be seen as `text/plain` for content type. This PR will fix it.